### PR TITLE
ci: enforce lowercase like conventional commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -30,14 +30,14 @@ jobs:
           requireScope: false
           # Configure additional validation for the subject based on a regex.
           # This example ensures the subject starts with an uppercase character.
-          subjectPattern: ^[A-Z].+$
+          subjectPattern: ^[a-a].+$
           # If `subjectPattern` is configured, you can use this property to override
           # the default error message that is shown when the pattern doesn't match.
           # The variables `subject` and `title` can be used within the message.
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the configured pattern. Please ensure that the subject
-            starts with an uppercase character.
+            starts with an lowercase character.
           # For work-in-progress PRs you can typically use draft pull requests
           # from Github. However, private repositories on the free plan don't have
           # this option and therefore this action allows you to opt-in to using the


### PR DESCRIPTION
Match style here with conventional commits, not upstream clowdhaus since we use CC internally and out style uses lowercase ;-)  